### PR TITLE
Fix Quick Start Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ yarn add accessible-astro-components
 
 ```astro
 ---
-import { Accordion, Card, Modal } from 'accessible-astro-components'
+import { Accordion, AccordionItem } from 'accessible-astro-components'
 ---
 
 <Accordion>


### PR DESCRIPTION
The Quick Start Example missed an import AccordionItem and I removed the unnecessary imports.