### PR TITLE
Add portal and z-index option to Toast for more flexibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessible-astro-components",
   "description": "A comprehensive set of accessible, easy-to-use UI components for Astro websites, built with WCAG compliance and inclusive design principles.",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": "Incluud",
   "license": "MIT",
   "homepage": "https://accessible-astro.incluud.dev/components/overview/",

--- a/src/components/toast/ToastProvider.astro
+++ b/src/components/toast/ToastProvider.astro
@@ -48,7 +48,9 @@ interface Props {
    */
   portal?: boolean
   /**
-   * Inline styles to apply to the toast provider
+   * Inline styles to apply to the toast provider.
+   * These are appended after the computed zIndex style, so avoid declaring
+   * `--toast-z-index` here unless you intentionally want to override `zIndex`.
    */
   style?: string
   /**

--- a/src/components/toast/ToastProvider.astro
+++ b/src/components/toast/ToastProvider.astro
@@ -38,6 +38,20 @@ interface Props {
    */
   ariaLabel?: string
   /**
+   * CSS z-index value for the toast provider
+   * @default "var(--z-index-8, 80)"
+   */
+  zIndex?: string | number
+  /**
+   * Move the provider to document.body on initialization to escape ancestor stacking contexts
+   * @default false
+   */
+  portal?: boolean
+  /**
+   * Inline styles to apply to the toast provider
+   */
+  style?: string
+  /**
    * HTML attributes to spread on the toast provider
    */
   [key: string]: string | number | boolean | undefined
@@ -49,18 +63,27 @@ const {
   duration = 5000,
   maxToasts = 5,
   ariaLabel = 'Notifications',
+  zIndex,
+  portal = false,
+  style,
   ...rest
 } = Astro.props
+
+const providerStyle = [zIndex !== undefined ? `--toast-z-index: ${zIndex}` : undefined, style]
+  .filter(Boolean)
+  .join('; ')
 ---
 
 <div
   class:list={['toast-provider', className]}
+  style={providerStyle || undefined}
   role="log"
   aria-label={ariaLabel}
   data-toast-provider
   data-position={position}
   data-duration={duration}
   data-max-toasts={maxToasts}
+  data-portal={portal ? 'true' : undefined}
   {...rest}
 >
   <template data-toast-template>
@@ -264,6 +287,10 @@ const {
 
     if (!state.provider) return
 
+    if (state.provider.dataset.portal === 'true' && state.provider.parentElement !== document.body) {
+      document.body.appendChild(state.provider)
+    }
+
     state.keydownController = new AbortController()
     document.addEventListener(
       'keydown',
@@ -301,7 +328,7 @@ const {
     position: fixed;
     flex-direction: column;
     gap: var(--space-xs);
-    z-index: var(--z-index-2);
+    z-index: var(--toast-z-index, var(--z-index-8, 80));
     inline-size: min(90vw, 420px);
     pointer-events: none;
   }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -673,6 +673,7 @@ export const Toast: Toast
  * @param _props.ariaLabel - Accessible label for the toast region - default: 'Notifications'
  * @param _props.zIndex - CSS z-index value applied through `--toast-z-index` - default: 'var(--z-index-8, 80)'
  * @param _props.portal - Move the provider to document.body on initialization to escape ancestor stacking contexts - default: false
+ * @param _props.style - Inline styles appended after the computed `zIndex` style. Avoid declaring `--toast-z-index` here unless intentionally overriding `zIndex`
  * @note Additional HTML attributes can be passed and will be spread to the root element
  * @note Exposes `window.toast` API with `show`, typed shortcut helpers, `dismiss`, and `dismissAll`
  * @note Dispatches `toast:show` and `toast:dismiss` CustomEvents on `document`

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -671,6 +671,8 @@ export const Toast: Toast
  * @param _props.duration - Default duration before auto-dismiss in milliseconds - default: 5000
  * @param _props.maxToasts - Maximum number of toasts to display - default: 5
  * @param _props.ariaLabel - Accessible label for the toast region - default: 'Notifications'
+ * @param _props.zIndex - CSS z-index value applied through `--toast-z-index` - default: 'var(--z-index-8, 80)'
+ * @param _props.portal - Move the provider to document.body on initialization to escape ancestor stacking contexts - default: false
  * @note Additional HTML attributes can be passed and will be spread to the root element
  * @note Exposes `window.toast` API with `show`, typed shortcut helpers, `dismiss`, and `dismissAll`
  * @note Dispatches `toast:show` and `toast:dismiss` CustomEvents on `document`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable z-index for toast stacking control.
  * Portal option to render the toast provider into the document body for improved layering and visibility.
  * Custom inline style support for toast provider customization.

* **Chores**
  * Version bumped to 5.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->