### PR TITLE
Add localization props for validation messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessible-astro-components",
   "description": "A comprehensive set of accessible, easy-to-use UI components for Astro websites, built with WCAG compliance and inclusive design principles.",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "author": "Incluud",
   "license": "MIT",
   "homepage": "https://accessible-astro.incluud.dev/components/overview/",

--- a/src/components/forms/Fieldset.astro
+++ b/src/components/forms/Fieldset.astro
@@ -23,6 +23,16 @@ interface Props {
    */
   required?: boolean
   /**
+   * Text displayed next to required fieldset legends
+   * @default "(required)"
+   */
+  requiredText?: string
+  /**
+   * Default validation message for required fieldsets
+   * @default "Please select at least one option"
+   */
+  requiredValidationMessage?: string
+  /**
    * Error message to display when group validation fails
    */
   'data-validation'?: string
@@ -45,6 +55,8 @@ const {
   id,
   legend,
   required = false,
+  requiredText = '(required)',
+  requiredValidationMessage = 'Please select at least one option',
   'data-validation': dataValidation,
   class: className,
   variant = 'default',
@@ -55,7 +67,7 @@ const fieldsetId = id || `fieldset-${name}`
 
 // Generate default validation message for groups
 const getDefaultValidationMessage = (isRequired: boolean): string => {
-  return isRequired ? 'Please select at least one option' : ''
+  return isRequired ? requiredValidationMessage : ''
 }
 
 // Use provided validation message or default
@@ -73,7 +85,7 @@ const validationMessage = dataValidation || getDefaultValidationMessage(required
 >
   <legend>
     {legend}
-    {required && <span>(required)</span>}
+    {required && requiredText && <span>{requiredText}</span>}
   </legend>
   <div class="fieldset-group">
     <slot />

--- a/src/components/forms/Form.astro
+++ b/src/components/forms/Form.astro
@@ -40,6 +40,21 @@ interface Props {
    * @default "on"
    */
   autocomplete?: 'on' | 'off'
+  /**
+   * Error summary message displayed when form validation fails
+   * @default "There was a problem with your submission. The following inputs need attention:"
+   */
+  errorSummaryMessage?: string
+  /**
+   * Fallback validation message for invalid fields without a custom data-validation value
+   * @default "This field is required"
+   */
+  defaultFieldValidationMessage?: string
+  /**
+   * Fallback validation message for invalid fieldsets without a custom data-validation value
+   * @default "Please select at least one option"
+   */
+  defaultFieldsetValidationMessage?: string
 }
 
 const {
@@ -50,6 +65,9 @@ const {
   enctype = 'application/x-www-form-urlencoded',
   target = '_self',
   autocomplete = 'on',
+  errorSummaryMessage = 'There was a problem with your submission. The following inputs need attention:',
+  defaultFieldValidationMessage = 'This field is required',
+  defaultFieldsetValidationMessage = 'Please select at least one option',
   ...rest
 } = Astro.props
 ---
@@ -61,6 +79,9 @@ const {
   enctype={enctype}
   target={target}
   autocomplete={autocomplete}
+  data-error-summary-message={errorSummaryMessage}
+  data-default-field-validation-message={defaultFieldValidationMessage}
+  data-default-fieldset-validation-message={defaultFieldsetValidationMessage}
   novalidate
   {...rest}
 >
@@ -83,6 +104,32 @@ const {
       const requiredFieldsets = form.querySelectorAll('fieldset[data-required="true"]')
       const errorNotification = form.querySelector('.notification') as HTMLElement | null
       const errorNotificationContent = errorNotification?.querySelector('p') as HTMLElement | null
+      const defaultMessages = {
+        errorSummary:
+          form.dataset.errorSummaryMessage ||
+          'There was a problem with your submission. The following inputs need attention:',
+        field: form.dataset.defaultFieldValidationMessage || 'This field is required',
+        fieldset:
+          form.dataset.defaultFieldsetValidationMessage || 'Please select at least one option',
+      }
+
+      const escapeHTML = (value) =>
+        String(value ?? '').replace(/[&<>"']/g, (character) => {
+          switch (character) {
+            case '&':
+              return '&amp;'
+            case '<':
+              return '&lt;'
+            case '>':
+              return '&gt;'
+            case '"':
+              return '&quot;'
+            case "'":
+              return '&#39;'
+            default:
+              return character
+          }
+        })
 
       // Secure regex pattern validation helper
       const validateCustomPattern = (pattern: string, value: string): boolean => {
@@ -221,23 +268,30 @@ const {
 
         errorNotificationContent.innerHTML = `
           <div class="space-content">
-            <p>There was a problem with your submission. The following inputs need attention:</p>
+            <p>${escapeHTML(defaultMessages.errorSummary)}</p>
             <ol class="incremented">
               ${elements
                 .map((element) => {
+                  const elementId = escapeHTML(element.id)
+
                   if (element.tagName === 'FIELDSET') {
                     const legend = element.querySelector('legend')
-                    const legendText = legend?.textContent || element.getAttribute('name')
-                    const validation =
-                      element.dataset.validation || 'Please select at least one option'
-                    return `<li><a href="#${element.id}">${legendText}: ${validation}</a></li>`
+                    const legendText = escapeHTML(
+                      legend?.textContent || element.getAttribute('name')
+                    )
+                    const validation = escapeHTML(
+                      element.dataset.validation || defaultMessages.fieldset
+                    )
+                    return `<li><a href="#${elementId}">${legendText}: ${validation}</a></li>`
                   } else {
                     const label = element
                       .closest('.input-group, .checkbox-group, .textarea-group')
                       ?.querySelector('label')
-                    const labelText = label?.textContent || element.name
-                    const validation = label?.dataset.validation || 'This field is required'
-                    return `<li><a href="#${element.id}">${labelText}: ${validation}</a></li>`
+                    const labelText = escapeHTML(label?.textContent || element.name)
+                    const validation = escapeHTML(
+                      label?.dataset.validation || defaultMessages.field
+                    )
+                    return `<li><a href="#${elementId}">${labelText}: ${validation}</a></li>`
                   }
                 })
                 .join('')}
@@ -254,7 +308,7 @@ const {
           const label = field
             .closest('.input-group, .checkbox-group, .textarea-group')
             ?.querySelector('label')
-          const validation = label?.dataset.validation || 'This field is required'
+          const validation = label?.dataset.validation || defaultMessages.field
           const messageElement = field.nextElementSibling?.querySelector('.message') as HTMLElement
 
           if (messageElement) {
@@ -265,7 +319,7 @@ const {
 
       const setFieldsetMessages = (fieldsets) => {
         fieldsets.forEach((fieldset) => {
-          const validation = fieldset.dataset.validation || 'Please select at least one option'
+          const validation = fieldset.dataset.validation || defaultMessages.fieldset
           const messageElement = fieldset.querySelector('.message') as HTMLElement
 
           if (messageElement) {

--- a/src/components/forms/Form.stories.ts
+++ b/src/components/forms/Form.stories.ts
@@ -109,3 +109,79 @@ export const Basic = {
     after: '<button type="submit">Send message</button>',
   },
 }
+
+export const LocalizedGerman = {
+  args: {
+    ...baseArgs,
+    errorSummaryMessage:
+      'Es gab ein Problem mit Ihrer Eingabe. Die folgenden Felder benoetigen Aufmerksamkeit:',
+    defaultFieldValidationMessage: 'Dieses Feld ist erforderlich',
+    defaultFieldsetValidationMessage: 'Bitte waehlen Sie mindestens eine Option',
+    children: [
+      {
+        Component: Input,
+        props: {
+          name: 'full-name',
+          label: 'Vollstaendiger Name',
+          required: true,
+          requiredText: '(Pflichtfeld)',
+          requiredValidationMessage: 'Bitte geben Sie Ihren vollstaendigen Namen ein',
+        },
+      },
+      {
+        Component: Input,
+        props: {
+          name: 'email',
+          label: 'E-Mail-Adresse',
+          type: 'email',
+          required: true,
+          requiredText: '(Pflichtfeld)',
+          autocomplete: 'email',
+          emailValidationMessage: 'Bitte geben Sie eine gueltige E-Mail-Adresse ein',
+        },
+      },
+      {
+        Component: Textarea,
+        props: {
+          name: 'message',
+          label: 'Nachricht',
+          required: true,
+          requiredText: '(Pflichtfeld)',
+          rows: 4,
+          placeholder: 'Erzaehlen Sie uns etwas ueber Ihr Projekt...',
+          requiredValidationMessage: 'Bitte fuegen Sie eine kurze Nachricht hinzu',
+        },
+      },
+      {
+        Component: Fieldset,
+        props: {
+          name: 'updates',
+          legend: 'E-Mail-Einstellungen',
+          required: true,
+          requiredText: '(Pflichtfeld)',
+          requiredValidationMessage: 'Bitte waehlen Sie mindestens eine Option',
+        },
+        children: [
+          {
+            Component: Checkbox,
+            props: {
+              name: 'updates',
+              label: 'Produkt-Updates',
+              value: 'product',
+            },
+          },
+          {
+            Component: Checkbox,
+            props: {
+              name: 'updates',
+              label: 'Sicherheitsmeldungen',
+              value: 'security',
+            },
+          },
+        ],
+      },
+    ],
+    afterIsHtml: true,
+    after: '<button type="submit">Nachricht senden</button>',
+  },
+}

--- a/src/components/forms/Input.astro
+++ b/src/components/forms/Input.astro
@@ -25,7 +25,7 @@ interface Props {
   /**
    * Error message to display when validation fails
    */
-  'data-validation': string
+  'data-validation'?: string
   /**
    * Input type (determines built-in validation rules)
    * @default "text"
@@ -36,6 +36,36 @@ interface Props {
    * @default false
    */
   required?: boolean
+  /**
+   * Text displayed next to required field labels
+   * @default "(required)"
+   */
+  requiredText?: string
+  /**
+   * Default validation message for required text fields
+   * @default "This field is required"
+   */
+  requiredValidationMessage?: string
+  /**
+   * Default validation message for email fields
+   * @default "Please provide an email address, for example houston@astro.build"
+   */
+  emailValidationMessage?: string
+  /**
+   * Default validation message for telephone fields
+   * @default "Please provide a valid phone number"
+   */
+  telValidationMessage?: string
+  /**
+   * Default validation message for password fields
+   * @default "Password must be at least 8 characters long"
+   */
+  passwordValidationMessage?: string
+  /**
+   * Default validation message for URL fields
+   * @default "Please provide a valid URL, for example https://astro.build"
+   */
+  urlValidationMessage?: string
   /**
    * Custom validation pattern (regex)
    */
@@ -77,6 +107,12 @@ const {
   'data-validation': dataValidation,
   type = 'text',
   required = false,
+  requiredText = '(required)',
+  requiredValidationMessage = 'This field is required',
+  emailValidationMessage = 'Please provide an email address, for example houston@astro.build',
+  telValidationMessage = 'Please provide a valid phone number',
+  passwordValidationMessage = 'Password must be at least 8 characters long',
+  urlValidationMessage = 'Please provide a valid URL, for example https://astro.build',
   'data-validation-pattern': dataValidationPattern,
   'data-validation-fn': dataValidationFn,
   value,
@@ -92,16 +128,16 @@ const inputId = id || `input-${name}`
 const getDefaultValidationMessage = (inputType: string, isRequired: boolean): string => {
   switch (inputType) {
     case 'email':
-      return 'Please provide an email address, for example houston@astro.build'
+      return emailValidationMessage
     case 'tel':
-      return 'Please provide a valid phone number'
+      return telValidationMessage
     case 'password':
-      return 'Password must be at least 8 characters long'
+      return passwordValidationMessage
     case 'url':
-      return 'Please provide a valid URL, for example https://astro.build'
+      return urlValidationMessage
     case 'text':
     default:
-      return isRequired ? 'This field is required' : ''
+      return isRequired ? requiredValidationMessage : ''
   }
 }
 
@@ -116,7 +152,7 @@ const validationMessage = dataValidation || getDefaultValidationMessage(type, re
     data-validation={validationMessage}
   >
     <span>{label}</span>
-    {required && <span>(required)</span>}
+    {required && requiredText && <span>{requiredText}</span>}
   </label>
 
   <input

--- a/src/components/forms/Textarea.astro
+++ b/src/components/forms/Textarea.astro
@@ -32,6 +32,16 @@ interface Props {
    */
   required?: boolean
   /**
+   * Text displayed next to required field labels
+   * @default "(required)"
+   */
+  requiredText?: string
+  /**
+   * Default validation message for required textareas
+   * @default "This field is required"
+   */
+  requiredValidationMessage?: string
+  /**
    * Custom validation pattern (regex)
    */
   'data-validation-pattern'?: string
@@ -79,6 +89,8 @@ const {
   label,
   'data-validation': dataValidation,
   required = false,
+  requiredText = '(required)',
+  requiredValidationMessage = 'This field is required',
   'data-validation-pattern': dataValidationPattern,
   'data-validation-fn': dataValidationFn,
   value,
@@ -95,7 +107,7 @@ const inputId = id || `textarea-${name}`
 
 // Generate default validation message
 const getDefaultValidationMessage = (isRequired: boolean): string => {
-  return isRequired ? 'This field is required' : ''
+  return isRequired ? requiredValidationMessage : ''
 }
 
 // Use provided validation message or default
@@ -105,7 +117,7 @@ const validationMessage = dataValidation || getDefaultValidationMessage(required
 <div class="textarea-group">
   <label for={inputId} data-validation={validationMessage}>
     <span>{label}</span>
-    {required && <span>(required)</span>}
+    {required && requiredText && <span>{requiredText}</span>}
   </label>
 
   <textarea

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -331,6 +331,8 @@ export const DarkMode: DarkMode
  * @param _props.id - Unique identifier for the fieldset
  * @param _props.legend - Legend text for the fieldset (required)
  * @param _props.required - Whether the fieldset group is required (at least one selection) - default: false
+ * @param _props.requiredText - Text displayed next to required fieldset legends - default: '(required)'
+ * @param _props.requiredValidationMessage - Default validation message for required fieldsets - default: 'Please select at least one option'
  * @param _props.data-validation - Error message to display when group validation fails
  * @param _props.class - Optional CSS class names
  * @param _props.variant - Variant of the fieldset ('default' | 'minimal') - default: 'default'
@@ -353,6 +355,9 @@ export const Fieldset: Fieldset
  * @param _props.enctype - Encoding type for form data ('application/x-www-form-urlencoded' | 'multipart/form-data' | 'text/plain') - default: 'application/x-www-form-urlencoded'
  * @param _props.target - Target for form submission ('_self' | '_blank' | '_parent' | '_top') - default: '_self'
  * @param _props.autocomplete - Autocomplete behavior ('on' | 'off') - default: 'on'
+ * @param _props.errorSummaryMessage - Error summary message displayed when form validation fails
+ * @param _props.defaultFieldValidationMessage - Fallback validation message for invalid fields without a custom data-validation value
+ * @param _props.defaultFieldsetValidationMessage - Fallback validation message for invalid fieldsets without a custom data-validation value
  * @param _props.children - Form controls and content. Parent element: `<form>`
  * @note Additional HTML attributes can be passed and will be spread to the root element
  * @note Includes built-in progressive enhancement validation with error handling
@@ -402,6 +407,12 @@ export const HighContrast: HighContrast
  * @param _props.data-validation - Optional custom error message to override automatically generated validation messages
  * @param _props.type - Input type determining built-in validation rules ('text' | 'email' | 'password' | 'tel' | 'url') - default: 'text'
  * @param _props.required - Whether the field is required - default: false
+ * @param _props.requiredText - Text displayed next to required field labels - default: '(required)'
+ * @param _props.requiredValidationMessage - Default validation message for required text fields - default: 'This field is required'
+ * @param _props.emailValidationMessage - Default validation message for email fields
+ * @param _props.telValidationMessage - Default validation message for telephone fields
+ * @param _props.passwordValidationMessage - Default validation message for password fields
+ * @param _props.urlValidationMessage - Default validation message for URL fields
  * @param _props.data-validation-pattern - Custom validation pattern (regex)
  * @param _props.data-validation-fn - Custom validation function name (must be available on window)
  * @param _props.value - Default value for the input field
@@ -630,6 +641,8 @@ export const TabsTab: TabsTab
  * @param _props.label - Label text for the textarea field (required)
  * @param _props.data-validation - Error message to display when validation fails
  * @param _props.required - Whether the field is required - default: false
+ * @param _props.requiredText - Text displayed next to required field labels - default: '(required)'
+ * @param _props.requiredValidationMessage - Default validation message for required textareas - default: 'This field is required'
  * @param _props.data-validation-pattern - Custom validation pattern (regex)
  * @param _props.data-validation-fn - Custom validation function name (must be available on window)
  * @param _props.disabled - Whether the field is disabled - default: false


### PR DESCRIPTION
## Summary
- Added customizable required labels and validation messages for `Input`, `Textarea`, and `Fieldset`
- Added form-level fallback messages for error summary, fields, and fieldsets via `Form`
- Hardened the form error summary rendering against HTML injection by escaping dynamic text
- Added a localized German story to demonstrate non-English configuration

#150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable “required” label text and required validation messages across Fieldset, Input, and Textarea.
  * Enhanced Form copy with configurable error summary and default validation messaging (now driven by component settings).
  * Added a localized German Storybook example.

* **Bug Fixes**
  * Improved safety of validation/error-summary rendering by escaping dynamic content.
  * Required indicators now render only when the field is configured to show them.

* **Chores**
  * Bumped package version to 5.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->