### PR TITLE
Pin npm to 11.5.1 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
+      # Ensure npm 11.5.1 is installed for trusted publishing on Node 20
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish


### PR DESCRIPTION
Update the publish workflow to use a specific npm version (11.5.1) instead of the latest version. This ensures consistent and reproducible builds, and is required for npm's trusted publishing feature to work correctly with Node 20. The comment is also updated to clarify the reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release publishing setup to use a fixed npm version for more reliable builds and deployments.
  * Clarified the publishing requirements in the setup notes for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->