### PR TITLE
fix(package): drop sideEffects field that bloated consumer CSS output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessible-astro-components",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "accessible-astro-components",
-      "version": "5.7.0",
+      "version": "5.7.1",
       "license": "MIT",
       "devDependencies": {
         "astro": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "accessible-astro-components",
   "description": "A comprehensive set of accessible, easy-to-use UI components for Astro websites, built with WCAG compliance and inclusive design principles.",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "author": "Incluud",
   "license": "MIT",
   "homepage": "https://accessible-astro.incluud.dev/components/overview/",
   "type": "module",
-  "sideEffects": [
-    "*.css"
-  ],
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
## Problem

5.7.0 added `"sideEffects": ["*.css"]` to `package.json`, intending to stop bundlers from tree-shaking the style import in `index.js`. That import was never at risk — with no `sideEffects` field, bundlers already treat every module as side-effectful.

What the field actually declares is that everything which is **not** CSS is side-effect-free. That let Rollup tree-shake the component barrel per page.

On a single-page build that looks like a win (56KB → 6.3KB for one component). On a real multi-page site it regresses badly:

1. Tree-shaking fragments one shared stylesheet into many small per-page chunks.
2. Every chunk under Astro's 4096-byte `inlineStylesheets: 'auto'` threshold gets **inlined into each page's HTML** — duplicated across every page and uncacheable.
3. The chunks that stay external are still linked from pages that never use them, because Astro collects a page's CSS from the *pre*-tree-shake module graph.

Reported downstream as: `404.html`, which uses no components at all, carrying ~20KB of inline CSS plus `Textarea.css` and `accessible-components.css`.

## Fix

Remove the `sideEffects` field. Output becomes byte-identical to 5.6.1 (verified — same chunk hash `9L6QqDYy`).

## Verification

Isolated the cause by removing only this field from an installed 5.7.0 in `node_modules` and rebuilding; that alone restored 5.6.1 output. Then measured against **accessible-astro-starter** (135 pages, Astro 7.2.2):

| | 5.7.0 | this PR |
|---|---|---|
| CSS assets | 3 files / 88,205 B | 1 file / 111,146 B |
| `404.html` inline CSS | 20,161 B | 2,147 B |
| `404.html` total size | 107,531 B | 89,347 B |
| **Site-wide inline CSS** | **2,713,259 B** | **369,158 B** |
| Total CSS payload | 2.80 MB | 0.48 MB (−83%) |

The 2,147 B still inline on `404.html` is the starter's own page CSS, not this package. The single 111KB stylesheet is shared and cached across all 135 pages.

## Scope

The rest of the 5.7.0 packaging work is deliberately untouched:

- `files` allowlist still holds the tarball at 49 files
- `./styles` and `./styles/*` subpath exports intact
- `astro` peerDependency (`^5 || ^6 || ^7`) intact

Version bumped to 5.7.1, lockfile synced.

## Not addressed here

The barrel export means importing one component still pulls every component's CSS into the shared stylesheet. That predates 5.7.0 and is unchanged by this PR — fixing it properly needs per-component subpath exports (`accessible-astro-components/Card`), which is an API change worth its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 5.7.1.
  * Removed CSS side-effect package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->